### PR TITLE
version selector picks first occurence

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ commands:
     - run:
         name: "Diff changes"
         command: |
-          thisversion=$(grep version: charts/edge-stack/Chart.yaml | awk ' { print $2 }')
+          thisversion=$(grep version: charts/edge-stack/Chart.yaml | awk ' { print $2 }' | sed -n 1p)
 
           if [[ "<< pipeline.git.tag >>" != "chart-v${thisversion}" ]]; then
             echo "Chart version ${thisversion} doesn't match tag << pipeline.git.tag >>; aborting"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ commands:
     - run:
         name: "Diff changes"
         command: |
-          thisversion=$(grep version: charts/edge-stack/Chart.yaml | awk ' { print $2 }' | sed -n 1p)
+          thisversion=$(grep ^version: charts/edge-stack/Chart.yaml | awk ' { print $2 }')
 
           if [[ "<< pipeline.git.tag >>" != "chart-v${thisversion}" ]]; then
             echo "Chart version ${thisversion} doesn't match tag << pipeline.git.tag >>; aborting"

--- a/.circleci/config.yml.d/amb_util.yml
+++ b/.circleci/config.yml.d/amb_util.yml
@@ -160,7 +160,7 @@ commands:
       - run:
           name: "Diff changes"
           command: |
-            thisversion=$(grep version: charts/edge-stack/Chart.yaml | awk ' { print $2 }' | sed -n 1p)
+            thisversion=$(grep ^version: charts/edge-stack/Chart.yaml | awk ' { print $2 }')
 
             if [[ "<< pipeline.git.tag >>" != "chart-v${thisversion}" ]]; then
               echo "Chart version ${thisversion} doesn't match tag << pipeline.git.tag >>; aborting"

--- a/.circleci/config.yml.d/amb_util.yml
+++ b/.circleci/config.yml.d/amb_util.yml
@@ -160,7 +160,7 @@ commands:
       - run:
           name: "Diff changes"
           command: |
-            thisversion=$(grep version: charts/edge-stack/Chart.yaml | awk ' { print $2 }')
+            thisversion=$(grep version: charts/edge-stack/Chart.yaml | awk ' { print $2 }' | sed -n 1p)
 
             if [[ "<< pipeline.git.tag >>" != "chart-v${thisversion}" ]]; then
               echo "Chart version ${thisversion} doesn't match tag << pipeline.git.tag >>; aborting"

--- a/charts/scripts/common.sh
+++ b/charts/scripts/common.sh
@@ -139,7 +139,7 @@ get_chart_version () {
     if [[ ! -f "${1}/Chart.yaml" ]] ; then
         abort "Chart.yaml not found in ${1}"
     fi
-    grep '^version:' ${1}/Chart.yaml | awk ' { print $2 }' | sed -n 1p
+    grep '^version:' ${1}/Chart.yaml | awk ' { print $2 }'
 }
 
 create_chart_release() {

--- a/charts/scripts/common.sh
+++ b/charts/scripts/common.sh
@@ -139,7 +139,7 @@ get_chart_version () {
     if [[ ! -f "${1}/Chart.yaml" ]] ; then
         abort "Chart.yaml not found in ${1}"
     fi
-    grep '^version:' ${1}/Chart.yaml | awk ' { print $2 }'
+    grep '^version:' ${1}/Chart.yaml | awk ' { print $2 }' | sed -n 1p
 }
 
 create_chart_release() {


### PR DESCRIPTION
Signed-off-by: AliceProxy <aliceproxy@protonmail.com>

The release CI fails at the moment because the selector for the current version of this chart returns two lines. This happens because Chart.yaml has a `version:` for this chart's version, and another at the bottom for the Emissary chart dependency version, so the `grep` slector will return two lines instead of one. I just added a `sed` to make it pick the first occurrence (This chart's version).

Check this failed CI build for an example:
https://app.circleci.com/pipelines/github/datawire/edge-stack/30/workflows/1118e628-908e-45dd-bba7-4f1b4478c160/jobs/64
