### PR TITLE
Expose imagePullSecrets and args

### DIFF
--- a/charts/edge-stack/templates/aes-redis.yaml
+++ b/charts/edge-stack/templates/aes-redis.yaml
@@ -90,6 +90,14 @@ spec:
         imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         resources:
         {{- toYaml .Values.redis.resources | nindent 10 }}
+        {{- if .Values.redis.containerArgs }}
+        args:
+        {{- toYaml .Values.redis.containerArgs | nindent 10 }}
+        {{- end }}
+      {{- if .Values.redis.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml .Values.redis.imagePullSecrets | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:

--- a/charts/edge-stack/values.yaml
+++ b/charts/edge-stack/values.yaml
@@ -158,6 +158,14 @@ redis:
   nodeSelector: {}
   affinity: {}
   tolerations: {}
+  # Arguments for the redis container
+  containerArgs: {}
+  #  - arg1
+  #  - arg2
+  # Secrets used for pulling the redis image from a private repo
+  imagePullSecrets: {}
+  #  - name: example-secret-1
+  #  - name: example-secret-2
 
 
 # Configures the AuthService that ships with the Ambassador Edge Stack.


### PR DESCRIPTION
Signed-off-by: AliceProxy <aliceproxy@protonmail.com>

Exposes imagePullSecrets and containers.args for the redis deployment. That's about all.