### PR TITLE
Correct wording in helm chart values

### DIFF
--- a/charts/edge-stack/values.yaml
+++ b/charts/edge-stack/values.yaml
@@ -105,7 +105,7 @@ global:
 # Go to https://{ambassador-host}/edge_stack/admin/#dashboard to register
 # for a community license key.
 
-# Set createSecret: false is installing multiple releases of The Ambassador
+# Set createSecret: false if installing multiple releases of The Ambassador
 # Edge Stack in the same namespace.
 licenseKey:
   value:

--- a/charts/edge-stack/values.yaml
+++ b/charts/edge-stack/values.yaml
@@ -105,8 +105,6 @@ global:
 # Go to https://{ambassador-host}/edge_stack/admin/#dashboard to register
 # for a community license key.
 
-# Set createSecret: false if installing multiple releases of The Ambassador
-# Edge Stack in the same namespace.
 licenseKey:
   value:
   createSecret: true


### PR DESCRIPTION
Actually I was getting errors on failing to mount a volume when I had this value to false, changing to true created a volume and attached a volume to a container, like this:

```
edge-stack-secrets:
   Type:        Secret (a volume populated by a Secret)
   SecretName:  edge-stack
   Optional:    false
```

https://github.com/datawire/edge-stack/blob/main/charts/edge-stack/values.yaml#L61

Was following this article: https://www.getambassador.io/docs/edge-stack/latest/topics/install/upgrade/helm/edge-stack-1.14/edge-stack-2.1/