### PR TITLE
No v1 needed for Hosts

### DIFF
--- a/manifests/edge-stack/aes-crds.yaml
+++ b/manifests/edge-stack/aes-crds.yaml
@@ -2513,14 +2513,6 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Host is the Schema for the hosts API
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: false
-    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Hosts never had a v1, so the unserved v1 isn't necessary.

Signed-off-by: Flynn <flynn@datawire.io>
