### PR TITLE
[v2.2] Agent-migration stuff for 2.2.0-rc.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,13 @@ HELM_OUTPUT_DIR := $(EDGE_STACK_HOME)/build/helm/
 
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-ambassadorns.yaml
+generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-ambassadorns-agent.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-ambassadorns-migration.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-defaultns.yaml
+generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-defaultns-agent.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-defaultns-migration.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-emissaryns.yaml
+generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-emissaryns-agent.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-emissaryns-migration.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/resources-migration.yaml
 generate/files += $(EDGE_STACK_HOME)/CHANGELOG.md
@@ -33,11 +36,14 @@ $(HELM_OUTPUT_DIR): $(EDGE_STACK_HOME)/charts/edge-stack/charts FORCE
 
 helm-namespace.aes                         = ambassador
 helm-namespace.aes-ambassadorns            = ambassador
+helm-namespace.aes-ambassadorns-agent      = ambassador
 helm-namespace.aes-ambassadorns-migration  = ambassador
 helm-namespace.aes-defaultns               = default
+helm-namespace.aes-defaultns-agent         = default
 helm-namespace.aes-defaultns-migration     = default
 helm-namespace.aes-emissaryns              = emissary
 helm-namespace.aes-emissaryns-migration    = emissary
+helm-namespace.aes-emissaryns-agent        = emissary
 helm-namespace.resources-migration         = default
 $(EDGE_STACK_HOME)/k8s-config/%/helm-expanded.yaml: \
   $(EDGE_STACK_HOME)/charts/edge-stack/charts \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ SHELL := /bin/bash
 HELM_OUTPUT_DIR := $(EDGE_STACK_HOME)/build/helm/
 
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes.yaml
+generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-ambassadorns.yaml
+generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-ambassadorns-migration.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-defaultns.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-defaultns-migration.yaml
 generate/files += $(EDGE_STACK_HOME)/manifests/edge-stack/aes-emissaryns.yaml
@@ -29,12 +31,14 @@ $(HELM_OUTPUT_DIR): $(EDGE_STACK_HOME)/charts/edge-stack/charts FORCE
 	mkdir -p $@
 	helm template edge-stack --output-dir $@ -n ambassador $(EDGE_STACK_HOME)/charts/edge-stack
 
-helm-namespace.aes                      = ambassador
-helm-namespace.aes-defaultns            = default
-helm-namespace.aes-defaultms-migration  = default
-helm-namespace.aes-emissaryns           = emissary
-helm-namespace.aes-emissaryns-migration = emissary
-helm-namespace.resources-migration      = default
+helm-namespace.aes                         = ambassador
+helm-namespace.aes-ambassadorns            = ambassador
+helm-namespace.aes-ambassadorns-migration  = ambassador
+helm-namespace.aes-defaultns               = default
+helm-namespace.aes-defaultns-migration     = default
+helm-namespace.aes-emissaryns              = emissary
+helm-namespace.aes-emissaryns-migration    = emissary
+helm-namespace.resources-migration         = default
 $(EDGE_STACK_HOME)/k8s-config/%/helm-expanded.yaml: \
   $(EDGE_STACK_HOME)/charts/edge-stack/charts \
   $(EDGE_STACK_HOME)/k8s-config/%/values.yaml \

--- a/k8s-config/aes-ambassadorns-agent/require.yaml
+++ b/k8s-config/aes-ambassadorns-agent/require.yaml
@@ -1,0 +1,13 @@
+resources:
+  - { kind: ServiceAccount,     name: edge-stack-agent,            namespace: ambassador }
+  - { kind: ClusterRole,        name: edge-stack-agent                                   }
+  - { kind: ClusterRole,        name: edge-stack-agent-pods                              }
+  - { kind: ClusterRole,        name: edge-stack-agent-deployments                       }
+  - { kind: ClusterRole,        name: edge-stack-agent-endpoints                         }
+  - { kind: ClusterRole,        name: edge-stack-agent-configmaps                        }
+  - { kind: ClusterRole,        name: edge-stack-agent-rollouts                          }
+  - { kind: ClusterRole,        name: edge-stack-agent-applications                      }
+  - { kind: ClusterRoleBinding, name: edge-stack-agent                                   }
+  - { kind: Role,               name: edge-stack-agent-config,     namespace: ambassador }
+  - { kind: RoleBinding,        name: edge-stack-agent-config,     namespace: ambassador }
+  - { kind: Deployment,         name: edge-stack-agent,            namespace: ambassador }

--- a/k8s-config/aes-ambassadorns-agent/values.yaml
+++ b/k8s-config/aes-ambassadorns-agent/values.yaml
@@ -1,0 +1,34 @@
+emissary-ingress:
+  deploymentTool: getambassador.io
+  replicaCount: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              product: aes
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+  env:
+    POLL_EVERY_SECS: '60'
+    AMBASSADOR_URL: 'https://ambassador.ambassador.svc.cluster.local'
+    AMBASSADOR_INTERNAL_URL: 'https://127.0.0.1:8443'
+    AMBASSADOR_DRAIN_TIME: '600'
+    AES_ACME_LEADER_DISABLE: 'true'
+  podAnnotations:
+    consul.hashicorp.com/connect-inject: 'false'
+    sidecar.istio.io/inject: 'false'
+  containerNameOverride: aes
+  restartPolicy: Always
+  terminationGracePeriodSeconds: "0"
+  service:
+    type: LoadBalancer
+  deploymentNameOverride: aes
+
+enableTestService: true
+
+deploymentTool: getambassador.io
+redis:
+  serviceSelector:
+    service: ambassador-redis

--- a/k8s-config/aes-ambassadorns-migration/require.yaml
+++ b/k8s-config/aes-ambassadorns-migration/require.yaml
@@ -1,0 +1,13 @@
+resources:
+  # everything else
+  - { kind: Service,            name: edge-stack-redis,     namespace: ambassador }
+  - { kind: Deployment,         name: edge-stack-redis,     namespace: ambassador }
+  - { kind: Secret,             name: edge-stack,           namespace: ambassador }
+  - { kind: Service,            name: test-aes,             namespace: ambassador }
+  - { kind: Deployment,         name: aes,                  namespace: ambassador }
+  - { kind: ServiceAccount,     name: edge-stack,           namespace: ambassador }
+  - { kind: ClusterRoleBinding, name: edge-stack                                  }
+  - { kind: ClusterRole,        name: edge-stack                                  }
+  - { kind: ClusterRole,        name: edge-stack-aes                              }
+  - { kind: ClusterRole,        name: edge-stack-crd                              }
+  - { kind: ClusterRole,        name: edge-stack-watch                            }

--- a/k8s-config/aes-ambassadorns-migration/values.yaml
+++ b/k8s-config/aes-ambassadorns-migration/values.yaml
@@ -1,0 +1,34 @@
+emissary-ingress:
+  deploymentTool: getambassador.io
+  replicaCount: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              product: aes
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+  env:
+    POLL_EVERY_SECS: '60'
+    AMBASSADOR_URL: 'https://ambassador.ambassador.svc.cluster.local'
+    AMBASSADOR_INTERNAL_URL: 'https://127.0.0.1:8443'
+    AMBASSADOR_DRAIN_TIME: '600'
+    AES_ACME_LEADER_DISABLE: 'true'
+  podAnnotations:
+    consul.hashicorp.com/connect-inject: 'false'
+    sidecar.istio.io/inject: 'false'
+  containerNameOverride: aes
+  restartPolicy: Always
+  terminationGracePeriodSeconds: "0"
+  service:
+    type: LoadBalancer
+  deploymentNameOverride: aes
+
+enableTestService: true
+
+deploymentTool: getambassador.io
+redis:
+  serviceSelector:
+    service: ambassador-redis

--- a/k8s-config/aes-ambassadorns/require.yaml
+++ b/k8s-config/aes-ambassadorns/require.yaml
@@ -1,0 +1,32 @@
+resources:
+ - { kind: Namespace,          name: ambassador                                         }
+ - { kind: ServiceAccount,     name: edge-stack-agent,            namespace: ambassador }
+ - { kind: ServiceAccount,     name: edge-stack,                  namespace: ambassador }
+ - { kind: Secret,             name: edge-stack,                  namespace: ambassador }
+ - { kind: ClusterRole,        name: edge-stack-agent                                   }
+ - { kind: ClusterRole,        name: edge-stack-agent-pods                              }
+ - { kind: ClusterRole,        name: edge-stack-agent-deployments                       }
+ - { kind: ClusterRole,        name: edge-stack-agent-endpoints                         }
+ - { kind: ClusterRole,        name: edge-stack-agent-configmaps                        }
+ - { kind: ClusterRole,        name: edge-stack-agent-rollouts                          }
+ - { kind: ClusterRole,        name: edge-stack-agent-applications                      }
+ - { kind: ClusterRole,        name: edge-stack                                         }
+ - { kind: ClusterRole,        name: edge-stack-crd                                     }
+ - { kind: ClusterRole,        name: edge-stack-watch                                   }
+ - { kind: ClusterRole,        name: edge-stack-aes                                     }
+ - { kind: ClusterRoleBinding, name: edge-stack-agent                                   }
+ - { kind: ClusterRoleBinding, name: edge-stack                                         }
+ - { kind: Role,               name: edge-stack-agent-config,     namespace: ambassador }
+ - { kind: RoleBinding,        name: edge-stack-agent-config,     namespace: ambassador }
+ - { kind: Service,            name: edge-stack-admin,            namespace: ambassador }
+ - { kind: Service,            name: edge-stack,                  namespace: ambassador }
+ - { kind: Service,            name: edge-stack-redis,            namespace: ambassador }
+ - { kind: Deployment,         name: edge-stack-agent,            namespace: ambassador }
+ - { kind: Deployment,         name: edge-stack,                  namespace: ambassador }
+ - { kind: Deployment,         name: edge-stack-redis,            namespace: ambassador }
+ - { kind: AuthService,        name: edge-stack-auth,             namespace: ambassador }
+ - { kind: Mapping,            name: edge-stack-devportal,        namespace: ambassador }
+ - { kind: Mapping,            name: edge-stack-devportal-assets, namespace: ambassador }
+ - { kind: Mapping,            name: edge-stack-devportal-demo,   namespace: ambassador }
+ - { kind: Mapping,            name: edge-stack-devportal-api,    namespace: ambassador }
+ - { kind: RateLimitService,   name: edge-stack-ratelimit,        namespace: ambassador }

--- a/k8s-config/aes-ambassadorns/values.yaml
+++ b/k8s-config/aes-ambassadorns/values.yaml
@@ -1,0 +1,39 @@
+emissary-ingress:
+  replicaCount: 1
+  createNamespace: true
+  deploymentTool: getambassador.io
+  env:
+    POLL_EVERY_SECS: '60'
+    AMBASSADOR_INTERNAL_URL: 'https://127.0.0.1:8443'
+    AMBASSADOR_DRAIN_TIME: '600'
+  podAnnotations:
+    consul.hashicorp.com/connect-inject: 'false'
+    sidecar.istio.io/inject: 'false'
+  containerNameOverride: aes
+  restartPolicy: Always
+  terminationGracePeriodSeconds: "0"
+  service:
+    type: LoadBalancer
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              service: ambassador
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+
+registry:
+  create: true
+devportal:
+  docsPrefix: "/docs/"
+authService:
+  optional_configurations:
+    allow_request_body: false
+    status_on_error:
+      code: 504
+redis:
+  serviceSelector:
+    service: ambassador-redis
+deploymentTool: getambassador.io

--- a/k8s-config/aes-defaultns-agent/require.yaml
+++ b/k8s-config/aes-defaultns-agent/require.yaml
@@ -1,0 +1,13 @@
+resources:
+  - { kind: ServiceAccount,     name: edge-stack-agent,            namespace: default }
+  - { kind: ClusterRole,        name: edge-stack-agent                                }
+  - { kind: ClusterRole,        name: edge-stack-agent-pods                           }
+  - { kind: ClusterRole,        name: edge-stack-agent-deployments                    }
+  - { kind: ClusterRole,        name: edge-stack-agent-endpoints                      }
+  - { kind: ClusterRole,        name: edge-stack-agent-configmaps                     }
+  - { kind: ClusterRole,        name: edge-stack-agent-rollouts                       }
+  - { kind: ClusterRole,        name: edge-stack-agent-applications                   }
+  - { kind: ClusterRoleBinding, name: edge-stack-agent                                }
+  - { kind: Role,               name: edge-stack-agent-config,     namespace: default }
+  - { kind: RoleBinding,        name: edge-stack-agent-config,     namespace: default }
+  - { kind: Deployment,         name: edge-stack-agent,            namespace: default }

--- a/k8s-config/aes-defaultns-agent/values.yaml
+++ b/k8s-config/aes-defaultns-agent/values.yaml
@@ -1,0 +1,34 @@
+emissary-ingress:
+  deploymentTool: getambassador.io
+  replicaCount: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              product: aes
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+  env:
+    POLL_EVERY_SECS: '60'
+    AMBASSADOR_URL: 'https://ambassador.ambassador.svc.cluster.local'
+    AMBASSADOR_INTERNAL_URL: 'https://127.0.0.1:8443'
+    AMBASSADOR_DRAIN_TIME: '600'
+    AES_ACME_LEADER_DISABLE: 'true'
+  podAnnotations:
+    consul.hashicorp.com/connect-inject: 'false'
+    sidecar.istio.io/inject: 'false'
+  containerNameOverride: aes
+  restartPolicy: Always
+  terminationGracePeriodSeconds: "0"
+  service:
+    type: LoadBalancer
+  deploymentNameOverride: aes
+
+enableTestService: true
+
+deploymentTool: getambassador.io
+redis:
+  serviceSelector:
+    service: ambassador-redis

--- a/k8s-config/aes-emissaryns-agent/require.yaml
+++ b/k8s-config/aes-emissaryns-agent/require.yaml
@@ -1,0 +1,13 @@
+resources:
+  - { kind: ServiceAccount,     name: edge-stack-agent,            namespace: emissary }
+  - { kind: ClusterRole,        name: edge-stack-agent                                 }
+  - { kind: ClusterRole,        name: edge-stack-agent-pods                            }
+  - { kind: ClusterRole,        name: edge-stack-agent-deployments                     }
+  - { kind: ClusterRole,        name: edge-stack-agent-endpoints                       }
+  - { kind: ClusterRole,        name: edge-stack-agent-configmaps                      }
+  - { kind: ClusterRole,        name: edge-stack-agent-rollouts                        }
+  - { kind: ClusterRole,        name: edge-stack-agent-applications                    }
+  - { kind: ClusterRoleBinding, name: edge-stack-agent                                 }
+  - { kind: Role,               name: edge-stack-agent-config,     namespace: emissary }
+  - { kind: RoleBinding,        name: edge-stack-agent-config,     namespace: emissary }
+  - { kind: Deployment,         name: edge-stack-agent,            namespace: emissary }

--- a/k8s-config/aes-emissaryns-agent/values.yaml
+++ b/k8s-config/aes-emissaryns-agent/values.yaml
@@ -1,0 +1,34 @@
+emissary-ingress:
+  deploymentTool: getambassador.io
+  replicaCount: 1
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              product: aes
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+  env:
+    POLL_EVERY_SECS: '60'
+    AMBASSADOR_URL: 'https://ambassador.ambassador.svc.cluster.local'
+    AMBASSADOR_INTERNAL_URL: 'https://127.0.0.1:8443'
+    AMBASSADOR_DRAIN_TIME: '600'
+    AES_ACME_LEADER_DISABLE: 'true'
+  podAnnotations:
+    consul.hashicorp.com/connect-inject: 'false'
+    sidecar.istio.io/inject: 'false'
+  containerNameOverride: aes
+  restartPolicy: Always
+  terminationGracePeriodSeconds: "0"
+  service:
+    type: LoadBalancer
+  deploymentNameOverride: aes
+
+enableTestService: true
+
+deploymentTool: getambassador.io
+redis:
+  serviceSelector:
+    service: ambassador-redis

--- a/manifests/edge-stack/aes-ambassadorns-agent.yaml
+++ b/manifests/edge-stack/aes-ambassadorns-agent.yaml
@@ -120,7 +120,7 @@ metadata:
 rules:
 - apiGroups: [argoproj.io]
   resources: [rollouts]
-  verbs: [get, list, watch]
+  verbs: [get, list, watch, patch]
 ---
 # Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -233,9 +233,12 @@ spec:
       serviceAccountName: edge-stack-agent
       containers:
       - name: agent
-        image: docker.io/datawire/aes:2.1.2
+        image: docker.io/datawire/aes:2.2.0-rc.0
         imagePullPolicy: IfNotPresent
         command: [agent]
+        ports:
+        - containerPort: 8006
+          name: grpc
         env:
         - name: AGENT_NAMESPACE
           valueFrom:

--- a/manifests/edge-stack/aes-ambassadorns-agent.yaml
+++ b/manifests/edge-stack/aes-ambassadorns-agent.yaml
@@ -1,0 +1,250 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-stack-agent
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: edge-stack-agent
+rules: []
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-pods
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [pods]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-deployments
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [apps, extensions]
+  resources: [deployments]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-endpoints
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-configmaps
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-rollouts
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [rollouts]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-applications
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [applications]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edge-stack-agent
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: ambassador
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edge-stack-agent-config
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edge-stack-agent-config
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edge-stack-agent-config
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: ambassador
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-stack-agent
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: edge-stack-agent
+      app.kubernetes.io/instance: edge-stack
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: edge-stack-agent
+
+        app.kubernetes.io/instance: edge-stack
+        app.kubernetes.io/part-of: edge-stack
+        app.kubernetes.io/managed-by: getambassador.io
+        product: aes
+    spec:
+      serviceAccountName: edge-stack-agent
+      containers:
+      - name: agent
+        image: docker.io/datawire/aes:2.1.2
+        imagePullPolicy: IfNotPresent
+        command: [agent]
+        env:
+        - name: AGENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: edge-stack-agent-cloud-token
+        - name: RPC_CONNECTION_ADDRESS
+          value: https://app.getambassador.io/
+        - name: AES_SNAPSHOT_URL
+          value: http://edge-stack-admin.ambassador:8005/snapshot-external
+  progressDeadlineSeconds: 600

--- a/manifests/edge-stack/aes-ambassadorns-migration.yaml
+++ b/manifests/edge-stack/aes-ambassadorns-migration.yaml
@@ -1,0 +1,378 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+# Source: edge-stack/templates/aes-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-stack-redis
+  namespace: ambassador
+  labels:
+    product: aes
+  annotations:
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/description: The Ambassador Edge Stack Redis store for auth and rate limiting,
+      among other things.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+    a8r.io/dependencies: None
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    service: ambassador-redis
+---
+# Source: edge-stack/templates/aes-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-stack-redis
+  namespace: ambassador
+  labels:
+    product: aes
+  annotations: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: ambassador-redis
+  template:
+    metadata:
+      labels:
+        service: ambassador-redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:5.0.1
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      restartPolicy: Always
+---
+# Source: edge-stack/templates/aes-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edge-stack
+  namespace: ambassador
+type: Opaque
+data:
+  license-key: ''
+---
+# Source: edge-stack/templates/oss-migration-test-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-aes
+  namespace: ambassador
+  labels:
+    product: aes
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: edge-stack
+    app.kubernetes.io/instance: edge-stack
+---
+# Source: edge-stack/charts/emissary-ingress/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aes
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: edge-stack
+      app.kubernetes.io/instance: edge-stack
+  strategy:
+    type: RollingUpdate
+
+
+  progressDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: edge-stack
+
+        app.kubernetes.io/instance: edge-stack
+        app.kubernetes.io/part-of: edge-stack
+        app.kubernetes.io/managed-by: getambassador.io
+        product: aes
+        profile: main
+      annotations:
+        consul.hashicorp.com/connect-inject: 'false'
+        sidecar.istio.io/inject: 'false'
+    spec:
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsUser: 8888
+      restartPolicy: Always
+      serviceAccountName: edge-stack
+      volumes:
+      - name: ambassador-pod-info
+        downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+      - name: edge-stack-secrets
+        secret:
+          secretName: edge-stack
+
+      containers:
+      - name: aes
+        image: docker.io/datawire/aes:2.1.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: https
+          containerPort: 8443
+        - name: admin
+          containerPort: 8877
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AES_ACME_LEADER_DISABLE
+          value: 'true'
+        - name: AMBASSADOR_DRAIN_TIME
+          value: '600'
+        - name: AMBASSADOR_INTERNAL_URL
+          value: https://127.0.0.1:8443
+        - name: AMBASSADOR_URL
+          value: https://ambassador.ambassador.svc.cluster.local
+        - name: POLL_EVERY_SECS
+          value: '60'
+        - name: REDIS_URL
+          value: edge-stack-redis:6379
+
+        securityContext:
+          allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /ambassador/v0/check_alive
+            port: admin
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /ambassador/v0/check_ready
+            port: admin
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        volumeMounts:
+        - name: ambassador-pod-info
+          mountPath: /tmp/ambassador-pod-info
+          readOnly: true
+
+        - name: edge-stack-secrets
+          mountPath: /.config/ambassador
+          readOnly: true
+
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+          requests:
+            cpu: 200m
+            memory: 300Mi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  product: aes
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      imagePullSecrets: []
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+---
+# Source: edge-stack/charts/emissary-ingress/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-stack
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edge-stack
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edge-stack
+subjects:
+- name: edge-stack
+  namespace: ambassador
+  kind: ServiceAccount
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+######################################################################
+# Aggregate                                                          #
+######################################################################
+# This ClusterRole has an empty `rules` and instead sets
+# `aggregationRule` in order to aggregate several other ClusterRoles
+# together, to avoid the need for multiple ClusterRoleBindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: edge-stack
+rules: []
+---
+# Source: edge-stack/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-aes
+  labels:
+    product: aes
+    rbac.getambassador.io/role-group: edge-stack
+rules:
+- apiGroups: ['']
+  resources: [secrets]
+  verbs: [get, list, watch, create, update]
+
+- apiGroups: ['']
+  resources: [events]
+  verbs: [get, list, watch, create, patch]
+
+- apiGroups: [coordination.k8s.io]
+  resources: [leases]
+  verbs: [get, create, update]
+
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, list, watch, create, update]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+######################################################################
+# No namespace                                                       #
+######################################################################
+# These ClusterRoles should be limited to resource types that are
+# non-namespaced, and therefore cannot be put in a Role, even if
+# Emissary is in single-namespace mode.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-crd
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+    rbac.getambassador.io/role-group: edge-stack
+rules:
+- apiGroups: [apiextensions.k8s.io]
+  resources: [customresourcedefinitions]
+  verbs: [get, list, watch, delete]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+######################################################################
+# All namespaces                                                     #
+######################################################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-watch
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+    rbac.getambassador.io/role-group: edge-stack
+rules:
+- apiGroups: ['']
+  resources:
+  - namespaces
+  - services
+  - secrets
+  - endpoints
+  verbs: [get, list, watch]
+
+- apiGroups: [getambassador.io]
+  resources: ['*']
+  verbs: [get, list, watch, update, patch, create, delete]
+
+- apiGroups: [getambassador.io]
+  resources: [mappings/status]
+  verbs: [update]
+
+- apiGroups: [networking.internal.knative.dev]
+  resources: [clusteringresses, ingresses]
+  verbs: [get, list, watch]
+
+- apiGroups: [networking.x-k8s.io]
+  resources: ['*']
+  verbs: [get, list, watch]
+
+- apiGroups: [networking.internal.knative.dev]
+  resources: [ingresses/status, clusteringresses/status]
+  verbs: [update]
+
+- apiGroups: [extensions, networking.k8s.io]
+  resources: [ingresses, ingressclasses]
+  verbs: [get, list, watch]
+
+- apiGroups: [extensions, networking.k8s.io]
+  resources: [ingresses/status]
+  verbs: [update]

--- a/manifests/edge-stack/aes-ambassadorns-migration.yaml
+++ b/manifests/edge-stack/aes-ambassadorns-migration.yaml
@@ -140,7 +140,7 @@ spec:
 
       containers:
       - name: aes
-        image: docker.io/datawire/aes:2.1.2
+        image: docker.io/datawire/aes:2.2.0-rc.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -150,6 +150,8 @@ spec:
         - name: admin
           containerPort: 8877
         env:
+        - name: AMBASSADOR_GRPC_METRICS_SINK
+          value: edge-stack:8006
         - name: HOST_IP
           valueFrom:
             fieldRef:
@@ -158,6 +160,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: edge-stack-agent-cloud-token
         - name: AES_ACME_LEADER_DISABLE
           value: 'true'
         - name: AMBASSADOR_DRAIN_TIME
@@ -346,6 +350,7 @@ rules:
   - namespaces
   - services
   - secrets
+  - configmaps
   - endpoints
   verbs: [get, list, watch]
 

--- a/manifests/edge-stack/aes-ambassadorns.yaml
+++ b/manifests/edge-stack/aes-ambassadorns.yaml
@@ -152,7 +152,7 @@ metadata:
 rules:
 - apiGroups: [argoproj.io]
   resources: [rollouts]
-  verbs: [get, list, watch]
+  verbs: [get, list, watch, patch]
 ---
 # Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -242,6 +242,7 @@ rules:
   - namespaces
   - services
   - secrets
+  - configmaps
   - endpoints
   verbs: [get, list, watch]
 
@@ -517,9 +518,12 @@ spec:
       serviceAccountName: edge-stack-agent
       containers:
       - name: agent
-        image: docker.io/datawire/aes:2.1.2
+        image: docker.io/datawire/aes:2.2.0-rc.0
         imagePullPolicy: IfNotPresent
         command: [agent]
+        ports:
+        - containerPort: 8006
+          name: grpc
         env:
         - name: AGENT_NAMESPACE
           valueFrom:
@@ -589,7 +593,7 @@ spec:
 
       containers:
       - name: aes
-        image: docker.io/datawire/aes:2.1.2
+        image: docker.io/datawire/aes:2.2.0-rc.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -599,6 +603,8 @@ spec:
         - name: admin
           containerPort: 8877
         env:
+        - name: AMBASSADOR_GRPC_METRICS_SINK
+          value: edge-stack:8006
         - name: HOST_IP
           valueFrom:
             fieldRef:
@@ -607,6 +613,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: edge-stack-agent-cloud-token
         - name: AMBASSADOR_DRAIN_TIME
           value: '600'
         - name: AMBASSADOR_INTERNAL_URL

--- a/manifests/edge-stack/aes-ambassadorns.yaml
+++ b/manifests/edge-stack/aes-ambassadorns.yaml
@@ -1,0 +1,777 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+# Source: edge-stack/charts/emissary-ingress/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    product: aes
+  name: ambassador
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-stack-agent
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+---
+# Source: edge-stack/charts/emissary-ingress/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-stack
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+---
+# Source: edge-stack/templates/aes-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: edge-stack
+  namespace: ambassador
+type: Opaque
+data:
+  license-key: ''
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: edge-stack-agent
+rules: []
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-pods
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [pods]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-deployments
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [apps, extensions]
+  resources: [deployments]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-endpoints
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-configmaps
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-rollouts
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [rollouts]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-applications
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [applications]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+######################################################################
+# Aggregate                                                          #
+######################################################################
+# This ClusterRole has an empty `rules` and instead sets
+# `aggregationRule` in order to aggregate several other ClusterRoles
+# together, to avoid the need for multiple ClusterRoleBindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: edge-stack
+rules: []
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+######################################################################
+# No namespace                                                       #
+######################################################################
+# These ClusterRoles should be limited to resource types that are
+# non-namespaced, and therefore cannot be put in a Role, even if
+# Emissary is in single-namespace mode.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-crd
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+    rbac.getambassador.io/role-group: edge-stack
+rules:
+- apiGroups: [apiextensions.k8s.io]
+  resources: [customresourcedefinitions]
+  verbs: [get, list, watch, delete]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+######################################################################
+# All namespaces                                                     #
+######################################################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-watch
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+    rbac.getambassador.io/role-group: edge-stack
+rules:
+- apiGroups: ['']
+  resources:
+  - namespaces
+  - services
+  - secrets
+  - endpoints
+  verbs: [get, list, watch]
+
+- apiGroups: [getambassador.io]
+  resources: ['*']
+  verbs: [get, list, watch, update, patch, create, delete]
+
+- apiGroups: [getambassador.io]
+  resources: [mappings/status]
+  verbs: [update]
+
+- apiGroups: [networking.internal.knative.dev]
+  resources: [clusteringresses, ingresses]
+  verbs: [get, list, watch]
+
+- apiGroups: [networking.x-k8s.io]
+  resources: ['*']
+  verbs: [get, list, watch]
+
+- apiGroups: [networking.internal.knative.dev]
+  resources: [ingresses/status, clusteringresses/status]
+  verbs: [update]
+
+- apiGroups: [extensions, networking.k8s.io]
+  resources: [ingresses, ingressclasses]
+  verbs: [get, list, watch]
+
+- apiGroups: [extensions, networking.k8s.io]
+  resources: [ingresses/status]
+  verbs: [update]
+---
+# Source: edge-stack/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-aes
+  labels:
+    product: aes
+    rbac.getambassador.io/role-group: edge-stack
+rules:
+- apiGroups: ['']
+  resources: [secrets]
+  verbs: [get, list, watch, create, update]
+
+- apiGroups: ['']
+  resources: [events]
+  verbs: [get, list, watch, create, patch]
+
+- apiGroups: [coordination.k8s.io]
+  resources: [leases]
+  verbs: [get, create, update]
+
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, list, watch, create, update]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edge-stack-agent
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: ambassador
+---
+# Source: edge-stack/charts/emissary-ingress/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edge-stack
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edge-stack
+subjects:
+- name: edge-stack
+  namespace: ambassador
+  kind: ServiceAccount
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edge-stack-agent-config
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edge-stack-agent-config
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edge-stack-agent-config
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: ambassador
+---
+# Source: edge-stack/charts/emissary-ingress/templates/admin-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-stack-admin
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    # Hard-coded label for Prometheus Operator ServiceMonitor
+    service: ambassador-admin
+    product: aes
+  annotations:
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/description: The Ambassador Edge Stack admin service for internal use and
+      health checks.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+    a8r.io/dependencies: None
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8877
+    targetPort: admin
+    protocol: TCP
+    name: ambassador-admin
+  - port: 8005
+    targetPort: 8005
+    protocol: TCP
+    name: ambassador-snapshot
+  selector:
+    app.kubernetes.io/name: edge-stack
+    app.kubernetes.io/instance: edge-stack
+---
+# Source: edge-stack/charts/emissary-ingress/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-stack
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/component: ambassador-service
+    product: aes
+  annotations:
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/description: The Ambassador Edge Stack goes beyond traditional API Gateways
+      and Ingress Controllers with the advanced edge features needed to support developer
+      self-service and full-cycle development.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+    a8r.io/dependencies: edge-stack-redis.ambassador
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: edge-stack
+    app.kubernetes.io/instance: edge-stack
+    profile: main
+---
+# Source: edge-stack/templates/aes-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-stack-redis
+  namespace: ambassador
+  labels:
+    product: aes
+  annotations:
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/description: The Ambassador Edge Stack Redis store for auth and rate limiting,
+      among other things.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+    a8r.io/dependencies: None
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    service: ambassador-redis
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-stack-agent
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: edge-stack-agent
+      app.kubernetes.io/instance: edge-stack
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: edge-stack-agent
+
+        app.kubernetes.io/instance: edge-stack
+        app.kubernetes.io/part-of: edge-stack
+        app.kubernetes.io/managed-by: getambassador.io
+        product: aes
+    spec:
+      serviceAccountName: edge-stack-agent
+      containers:
+      - name: agent
+        image: docker.io/datawire/aes:2.1.2
+        imagePullPolicy: IfNotPresent
+        command: [agent]
+        env:
+        - name: AGENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: edge-stack-agent-cloud-token
+        - name: RPC_CONNECTION_ADDRESS
+          value: https://app.getambassador.io/
+        - name: AES_SNAPSHOT_URL
+          value: http://edge-stack-admin.ambassador:8005/snapshot-external
+  progressDeadlineSeconds: 600
+---
+# Source: edge-stack/charts/emissary-ingress/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-stack
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: edge-stack
+      app.kubernetes.io/instance: edge-stack
+  strategy:
+    type: RollingUpdate
+
+
+  progressDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: edge-stack
+
+        app.kubernetes.io/instance: edge-stack
+        app.kubernetes.io/part-of: edge-stack
+        app.kubernetes.io/managed-by: getambassador.io
+        product: aes
+        profile: main
+      annotations:
+        consul.hashicorp.com/connect-inject: 'false'
+        sidecar.istio.io/inject: 'false'
+    spec:
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsUser: 8888
+      restartPolicy: Always
+      serviceAccountName: edge-stack
+      volumes:
+      - name: ambassador-pod-info
+        downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+      - name: edge-stack-secrets
+        secret:
+          secretName: edge-stack
+
+      containers:
+      - name: aes
+        image: docker.io/datawire/aes:2.1.2
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: https
+          containerPort: 8443
+        - name: admin
+          containerPort: 8877
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AMBASSADOR_DRAIN_TIME
+          value: '600'
+        - name: AMBASSADOR_INTERNAL_URL
+          value: https://127.0.0.1:8443
+        - name: POLL_EVERY_SECS
+          value: '60'
+        - name: REDIS_URL
+          value: edge-stack-redis:6379
+
+        securityContext:
+          allowPrivilegeEscalation: false
+        livenessProbe:
+          httpGet:
+            path: /ambassador/v0/check_alive
+            port: admin
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /ambassador/v0/check_ready
+            port: admin
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        volumeMounts:
+        - name: ambassador-pod-info
+          mountPath: /tmp/ambassador-pod-info
+          readOnly: true
+
+        - name: edge-stack-secrets
+          mountPath: /.config/ambassador
+          readOnly: true
+
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+          requests:
+            cpu: 200m
+            memory: 300Mi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  service: ambassador
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      imagePullSecrets: []
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+---
+# Source: edge-stack/templates/aes-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-stack-redis
+  namespace: ambassador
+  labels:
+    product: aes
+  annotations: {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: ambassador-redis
+  template:
+    metadata:
+      labels:
+        service: ambassador-redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:5.0.1
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      restartPolicy: Always
+---
+# Source: edge-stack/templates/aes-authservice.yaml
+apiVersion: getambassador.io/v2
+kind: AuthService
+metadata:
+  name: edge-stack-auth
+  namespace: ambassador
+  labels:
+    product: aes
+spec:
+  proto: grpc
+  auth_service: 127.0.0.1:8500
+  allow_request_body: false
+  status_on_error:
+    code: 504
+---
+# Source: edge-stack/templates/aes-internal.yaml
+# Configure DevPortal
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  # This Mapping name is referenced by convention, it's important to leave as-is.
+  name: edge-stack-devportal
+  namespace: ambassador
+  labels:
+    product: aes
+spec:
+  prefix: /docs/
+  rewrite: /docs/
+  service: 127.0.0.1:8500
+---
+# Source: edge-stack/templates/aes-internal.yaml
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: edge-stack-devportal-assets
+  namespace: ambassador
+  labels:
+    product: aes
+spec:
+  prefix: /documentation/(assets|styles)/(.*)(.css)
+  prefix_regex: true
+  regex_rewrite:
+    pattern: /documentation/(.*)
+    substitution: /docs/\1
+  service: 127.0.0.1:8500
+  add_response_headers:
+    cache-control:
+      value: public, max-age=3600, immutable
+      append: false
+---
+# Source: edge-stack/templates/aes-internal.yaml
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  # This Mapping name is what the demo uses. Sigh.
+  name: edge-stack-devportal-demo
+  namespace: ambassador
+  labels:
+    product: aes
+spec:
+  prefix: /docs/
+  rewrite: /docs/
+  service: 127.0.0.1:8500
+---
+# Source: edge-stack/templates/aes-internal.yaml
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  # This Mapping name is referenced by convention, it's important to leave as-is.
+  name: edge-stack-devportal-api
+  namespace: ambassador
+  labels:
+    product: aes
+spec:
+  prefix: /openapi/
+  rewrite: ''
+  service: 127.0.0.1:8500
+---
+# Source: edge-stack/templates/aes-ratelimit.yaml
+apiVersion: getambassador.io/v2
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit
+  namespace: ambassador
+  labels:
+    product: aes
+spec:
+  service: 127.0.0.1:8500

--- a/manifests/edge-stack/aes-crds.yaml
+++ b/manifests/edge-stack/aes-crds.yaml
@@ -2979,7 +2979,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver API
+        description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver
+          API
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: false
@@ -3083,7 +3084,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver API
+        description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver
+          API
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: false
@@ -4572,7 +4574,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: A Module defines system-wide configuration.  The type of module is controlled by the .metadata.name; valid names are "ambassador" or "tls".
+        description: A Module defines system-wide configuration.  The type of module
+          is controlled by the .metadata.name; valid names are "ambassador" or "tls".
         type: object
         x-kubernetes-preserve-unknown-fields: true
     served: false

--- a/manifests/edge-stack/aes-crds.yaml
+++ b/manifests/edge-stack/aes-crds.yaml
@@ -2880,14 +2880,6 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Host is the Schema for the hosts API
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: false
-    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/manifests/edge-stack/aes-crds.yaml
+++ b/manifests/edge-stack/aes-crds.yaml
@@ -1846,6 +1846,14 @@ spec:
         type: object
     served: true
     storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: AuthService is the Schema for the authservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1948,6 +1956,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ConsulResolver is the Schema for the ConsulResolver API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2215,6 +2231,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DevPortal is the Schema for the DevPortals API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2856,6 +2880,14 @@ spec:
     storage: false
     subresources:
       status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Host is the Schema for the hosts API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2952,6 +2984,14 @@ spec:
         type: object
     served: true
     storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3047,6 +3087,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -3397,6 +3445,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LogService is the Schema for the logservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4406,6 +4462,14 @@ spec:
     storage: false
     subresources:
       status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Mapping is the Schema for the mappings API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4512,6 +4576,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: A Module defines system-wide configuration.  The type of module is controlled by the .metadata.name; valid names are "ambassador" or "tls".
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4677,6 +4749,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitService is the Schema for the ratelimitservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -4905,6 +4985,14 @@ spec:
         type: object
     served: true
     storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TCPMapping is the Schema for the tcpmappings API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5087,6 +5175,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSContext is the Schema for the tlscontexts API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -5276,6 +5372,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TracingService is the Schema for the tracingservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 ################################################################################

--- a/manifests/edge-stack/aes-defaultns-agent.yaml
+++ b/manifests/edge-stack/aes-defaultns-agent.yaml
@@ -120,7 +120,7 @@ metadata:
 rules:
 - apiGroups: [argoproj.io]
   resources: [rollouts]
-  verbs: [get, list, watch]
+  verbs: [get, list, watch, patch]
 ---
 # Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -233,9 +233,12 @@ spec:
       serviceAccountName: edge-stack-agent
       containers:
       - name: agent
-        image: docker.io/datawire/aes:2.1.2
+        image: docker.io/datawire/aes:2.2.0-rc.0
         imagePullPolicy: IfNotPresent
         command: [agent]
+        ports:
+        - containerPort: 8006
+          name: grpc
         env:
         - name: AGENT_NAMESPACE
           valueFrom:

--- a/manifests/edge-stack/aes-defaultns-agent.yaml
+++ b/manifests/edge-stack/aes-defaultns-agent.yaml
@@ -1,0 +1,250 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-stack-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: edge-stack-agent
+rules: []
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-pods
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [pods]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-deployments
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [apps, extensions]
+  resources: [deployments]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-endpoints
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-configmaps
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-rollouts
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [rollouts]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-applications
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [applications]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edge-stack-agent
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: default
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edge-stack-agent-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edge-stack-agent-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edge-stack-agent-config
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: default
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-stack-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: edge-stack-agent
+      app.kubernetes.io/instance: edge-stack
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: edge-stack-agent
+
+        app.kubernetes.io/instance: edge-stack
+        app.kubernetes.io/part-of: edge-stack
+        app.kubernetes.io/managed-by: getambassador.io
+        product: aes
+    spec:
+      serviceAccountName: edge-stack-agent
+      containers:
+      - name: agent
+        image: docker.io/datawire/aes:2.1.2
+        imagePullPolicy: IfNotPresent
+        command: [agent]
+        env:
+        - name: AGENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: edge-stack-agent-cloud-token
+        - name: RPC_CONNECTION_ADDRESS
+          value: https://app.getambassador.io/
+        - name: AES_SNAPSHOT_URL
+          value: http://edge-stack-admin.default:8005/snapshot-external
+  progressDeadlineSeconds: 600

--- a/manifests/edge-stack/aes-emissaryns-agent.yaml
+++ b/manifests/edge-stack/aes-emissaryns-agent.yaml
@@ -120,7 +120,7 @@ metadata:
 rules:
 - apiGroups: [argoproj.io]
   resources: [rollouts]
-  verbs: [get, list, watch]
+  verbs: [get, list, watch, patch]
 ---
 # Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -233,9 +233,12 @@ spec:
       serviceAccountName: edge-stack-agent
       containers:
       - name: agent
-        image: docker.io/datawire/aes:2.1.2
+        image: docker.io/datawire/aes:2.2.0-rc.0
         imagePullPolicy: IfNotPresent
         command: [agent]
+        ports:
+        - containerPort: 8006
+          name: grpc
         env:
         - name: AGENT_NAMESPACE
           valueFrom:

--- a/manifests/edge-stack/aes-emissaryns-agent.yaml
+++ b/manifests/edge-stack/aes-emissaryns-agent.yaml
@@ -1,0 +1,250 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-stack-agent
+  namespace: emissary
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: edge-stack-agent
+rules: []
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-pods
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [pods]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-deployments
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [apps, extensions]
+  resources: [deployments]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-endpoints
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-configmaps
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-rollouts
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [rollouts]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: edge-stack-agent-applications
+  labels:
+    rbac.getambassador.io/role-group: edge-stack-agent
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: [argoproj.io]
+  resources: [applications]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: edge-stack-agent
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edge-stack-agent
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: emissary
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: edge-stack-agent-config
+  namespace: emissary
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+rules:
+- apiGroups: ['']
+  resources: [configmaps]
+  verbs: [get, list, watch]
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: edge-stack-agent-config
+  namespace: emissary
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: edge-stack-agent-config
+subjects:
+- kind: ServiceAccount
+  name: edge-stack-agent
+  namespace: emissary
+---
+# Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-stack-agent
+  namespace: emissary
+  labels:
+    app.kubernetes.io/name: edge-stack-agent
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    product: aes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: edge-stack-agent
+      app.kubernetes.io/instance: edge-stack
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: edge-stack-agent
+
+        app.kubernetes.io/instance: edge-stack
+        app.kubernetes.io/part-of: edge-stack
+        app.kubernetes.io/managed-by: getambassador.io
+        product: aes
+    spec:
+      serviceAccountName: edge-stack-agent
+      containers:
+      - name: agent
+        image: docker.io/datawire/aes:2.1.2
+        imagePullPolicy: IfNotPresent
+        command: [agent]
+        env:
+        - name: AGENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: edge-stack-agent-cloud-token
+        - name: RPC_CONNECTION_ADDRESS
+          value: https://app.getambassador.io/
+        - name: AES_SNAPSHOT_URL
+          value: http://edge-stack-admin.emissary:8005/snapshot-external
+  progressDeadlineSeconds: 600


### PR DESCRIPTION
Cherry-picked off `main` because we'll need it on `rel/v2.2.0`.