### PR TITLE
Include `edge-stack-admin` in the `-agent` files for migrations.

### DIFF
--- a/k8s-config/aes-ambassadorns-agent/require.yaml
+++ b/k8s-config/aes-ambassadorns-agent/require.yaml
@@ -10,4 +10,5 @@ resources:
   - { kind: ClusterRoleBinding, name: edge-stack-agent                                   }
   - { kind: Role,               name: edge-stack-agent-config,     namespace: ambassador }
   - { kind: RoleBinding,        name: edge-stack-agent-config,     namespace: ambassador }
+  - { kind: Service,            name: edge-stack-admin,            namespace: ambassador }
   - { kind: Deployment,         name: edge-stack-agent,            namespace: ambassador }

--- a/k8s-config/aes-defaultns-agent/require.yaml
+++ b/k8s-config/aes-defaultns-agent/require.yaml
@@ -10,4 +10,5 @@ resources:
   - { kind: ClusterRoleBinding, name: edge-stack-agent                                }
   - { kind: Role,               name: edge-stack-agent-config,     namespace: default }
   - { kind: RoleBinding,        name: edge-stack-agent-config,     namespace: default }
+  - { kind: Service,            name: edge-stack-admin,            namespace: default }
   - { kind: Deployment,         name: edge-stack-agent,            namespace: default }

--- a/k8s-config/aes-emissaryns-agent/require.yaml
+++ b/k8s-config/aes-emissaryns-agent/require.yaml
@@ -10,4 +10,5 @@ resources:
   - { kind: ClusterRoleBinding, name: edge-stack-agent                                 }
   - { kind: Role,               name: edge-stack-agent-config,     namespace: emissary }
   - { kind: RoleBinding,        name: edge-stack-agent-config,     namespace: emissary }
+  - { kind: Service,            name: edge-stack-admin,            namespace: emissary }
   - { kind: Deployment,         name: edge-stack-agent,            namespace: emissary }

--- a/manifests/edge-stack/aes-ambassadorns-agent.yaml
+++ b/manifests/edge-stack/aes-ambassadorns-agent.yaml
@@ -201,6 +201,46 @@ subjects:
   name: edge-stack-agent
   namespace: ambassador
 ---
+# Source: edge-stack/charts/emissary-ingress/templates/admin-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-stack-admin
+  namespace: ambassador
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    # Hard-coded label for Prometheus Operator ServiceMonitor
+    service: ambassador-admin
+    product: aes
+  annotations:
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/description: The Ambassador Edge Stack admin service for internal use and
+      health checks.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+    a8r.io/dependencies: None
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8877
+    targetPort: admin
+    protocol: TCP
+    name: ambassador-admin
+  - port: 8005
+    targetPort: 8005
+    protocol: TCP
+    name: ambassador-snapshot
+  selector:
+    app.kubernetes.io/name: edge-stack
+    app.kubernetes.io/instance: edge-stack
+---
 # Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/edge-stack/aes-defaultns-agent.yaml
+++ b/manifests/edge-stack/aes-defaultns-agent.yaml
@@ -201,6 +201,46 @@ subjects:
   name: edge-stack-agent
   namespace: default
 ---
+# Source: edge-stack/charts/emissary-ingress/templates/admin-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-stack-admin
+  namespace: default
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    # Hard-coded label for Prometheus Operator ServiceMonitor
+    service: ambassador-admin
+    product: aes
+  annotations:
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/description: The Ambassador Edge Stack admin service for internal use and
+      health checks.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+    a8r.io/dependencies: None
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8877
+    targetPort: admin
+    protocol: TCP
+    name: ambassador-admin
+  - port: 8005
+    targetPort: 8005
+    protocol: TCP
+    name: ambassador-snapshot
+  selector:
+    app.kubernetes.io/name: edge-stack
+    app.kubernetes.io/instance: edge-stack
+---
 # Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
 apiVersion: apps/v1
 kind: Deployment

--- a/manifests/edge-stack/aes-emissaryns-agent.yaml
+++ b/manifests/edge-stack/aes-emissaryns-agent.yaml
@@ -201,6 +201,46 @@ subjects:
   name: edge-stack-agent
   namespace: emissary
 ---
+# Source: edge-stack/charts/emissary-ingress/templates/admin-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-stack-admin
+  namespace: emissary
+  labels:
+    app.kubernetes.io/name: edge-stack
+
+    app.kubernetes.io/instance: edge-stack
+    app.kubernetes.io/part-of: edge-stack
+    app.kubernetes.io/managed-by: getambassador.io
+    # Hard-coded label for Prometheus Operator ServiceMonitor
+    service: ambassador-admin
+    product: aes
+  annotations:
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/description: The Ambassador Edge Stack admin service for internal use and
+      health checks.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+    a8r.io/dependencies: None
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8877
+    targetPort: admin
+    protocol: TCP
+    name: ambassador-admin
+  - port: 8005
+    targetPort: 8005
+    protocol: TCP
+    name: ambassador-snapshot
+  selector:
+    app.kubernetes.io/name: edge-stack
+    app.kubernetes.io/instance: edge-stack
+---
 # Source: edge-stack/charts/emissary-ingress/templates/ambassador-agent.yaml
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Make sure the `edge-stack-admin` service gets added by the agent migration files.

(Why the agent migration files instead of the main migration files? Because the
main `-migration` files are meant to leave the old agent running, not mess with
the agent for you. Instead, include it in the `-agent` files so that it gets
updated with the new agent.)

Signed-off-by: Flynn <flynn@datawire.io>
