### PR TITLE
Add transport protocol version crd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,17 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [2.3.0] TBD
+[2.3.0]: https://github.com/datawire/edge-stack/releases/v2.3.0
+
+## Ambassador Edge Stack
+
+- Feature: Ambassador Edge Stack now supports the use of transport protocol V3 in External Filters while
+  reatining compatability for V2.  To start using transport protocol V3, set the new
+  `protocol_version` field in an External Filter to `v3`. If the protocol version is not specified
+  then it will be assumed to be V2 which is the standard in Ambassador Edge Stack versions prior to
+  2.3. // TODO, link to a docs page that has not yet been created 
+
 ## [2.2.0] 2022-02-10
 [2.2.0]: https://github.com/datawire/edge-stack/releases/v2.2.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,17 @@
 
 changelog: https://github.com/datawire/edge-stack/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.3.0
+    date: 'TBD'
+    notes:
+      - title: Support for Envoy Transport Protocol V2 and V3 
+        type: feature
+        body: >-
+          $productName$ now supports the use of transport protocol V3 in External Filters while reatining compatability for V2. 
+          To start using transport protocol V3, set the new `protocol_version` field in an External Filter to `v3`. If the protocol version
+          is not specified then it will be assumed to be V2 which is the standard in $productName$ versions prior to 2.3.
+          // TODO, link to a docs page that has not yet been created 
+
   - version: 2.2.0
     date: '2022-02-10'
     notes:

--- a/manifests/edge-stack/aes-crds.yaml
+++ b/manifests/edge-stack/aes-crds.yaml
@@ -315,6 +315,11 @@ spec:
                     - http
                     - grpc
                     type: string
+                  protocol_version:
+                    enum:
+                    - v2
+                    - v3
+                    type: string
                   status_on_error:
                     properties:
                       code:
@@ -618,6 +623,11 @@ spec:
                     - http
                     - grpc
                     type: string
+                  protocol_version:
+                    enum:
+                    - v2
+                    - v3
+                    type: string
                   status_on_error:
                     properties:
                       code:
@@ -920,6 +930,11 @@ spec:
                     enum:
                     - http
                     - grpc
+                    type: string
+                  protocol_version:
+                    enum:
+                    - v2
+                    - v3
                     type: string
                   status_on_error:
                     description: 'TODO(lukeshu): In v3alpha2, consider getting rid


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>
Adds a new `protocol_version` field to the External Filter for configuring the transport protocol version. It will be assumed that the external filter is using transport protocol V2 unless this field is set to `v3`. 